### PR TITLE
Fix crash when sending a message when there's no internet connection

### DIFF
--- a/app/src/main/java/ch/tarsier/tarsier/event/ErrorConnectionEvent.java
+++ b/app/src/main/java/ch/tarsier/tarsier/event/ErrorConnectionEvent.java
@@ -1,0 +1,24 @@
+package ch.tarsier.tarsier.event;
+
+/**
+ * @author benpac
+ * This Event is launch when the connection is not initialized.
+ * This can happen is there is no Wifi on the device or if there is no
+ * devices connected to this one
+ */
+public class ErrorConnectionEvent {
+    private String mErrorMessage;
+
+    public ErrorConnectionEvent(String error) {
+        mErrorMessage = error;
+    }
+
+    public String getErrorMessage() {
+        return mErrorMessage;
+    }
+
+    public void setErrorMessage(String error) {
+        mErrorMessage = error;
+    }
+
+}

--- a/app/src/main/java/ch/tarsier/tarsier/network/MessagingManager.java
+++ b/app/src/main/java/ch/tarsier/tarsier/network/MessagingManager.java
@@ -30,6 +30,7 @@ import ch.tarsier.tarsier.domain.model.Peer;
 import ch.tarsier.tarsier.event.ConnectToDeviceEvent;
 import ch.tarsier.tarsier.event.ConnectedEvent;
 import ch.tarsier.tarsier.event.CreateGroupEvent;
+import ch.tarsier.tarsier.event.ErrorConnectionEvent;
 import ch.tarsier.tarsier.event.ReceivedChatroomPeersListEvent;
 import ch.tarsier.tarsier.event.ReceivedMessageEvent;
 import ch.tarsier.tarsier.event.ReceivedNearbyPeersListEvent;
@@ -340,9 +341,8 @@ public class MessagingManager extends BroadcastReceiver implements ConnectionInf
                 Log.d(NETWORK_LAYER_TAG, "Cannot send message that is neither private nor public.");
             }
         } else {
-            //mConnection is null. Message cannot be send to other user
-            //should leave the chat
             Log.d(NETWORK_LAYER_TAG,"mConnection is null. Cannot send message to nobody");
+            mEventBus.post(new ErrorConnectionEvent("Error : There is no connected devices. The message was not send"));
         }
     }
 

--- a/app/src/main/java/ch/tarsier/tarsier/ui/activity/ChatActivity.java
+++ b/app/src/main/java/ch/tarsier/tarsier/ui/activity/ChatActivity.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import ch.tarsier.tarsier.Tarsier;
 import ch.tarsier.tarsier.domain.model.Chat;
+import ch.tarsier.tarsier.event.ErrorConnectionEvent;
 import ch.tarsier.tarsier.event.ReceivedMessageEvent;
 import ch.tarsier.tarsier.event.SendMessageEvent;
 import ch.tarsier.tarsier.exception.InsertException;
@@ -203,6 +204,11 @@ public class ChatActivity extends Activity implements EndlessListener {
     protected void onPause() {
         super.onPause();
         mEventBus.unregister(this);
+    }
+
+    @Subscribe
+    public void onReceiveConnectionError(ErrorConnectionEvent event) {
+        Toast.makeText(this,event.getErrorMessage(),Toast.LENGTH_LONG).show();
     }
 
     /**


### PR DESCRIPTION
Ok so I had a look and actually it is the only place in MessagingManager where mConnection is not check for being null so I added it. This also add an event to show in ChatActivity that there is no connection and that the message is not send.

Closes #197.
